### PR TITLE
Add security guidelines for Rails applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ At this point, pivotal tracker automatically changes the status of the task to a
 
 * All code should be written in English.
 
+**Security Guidelines**
+
+* [Zen Rails Security Checklist](https://github.com/brunofacca/zen-rails-security-checklist)
+
 **Style**
 
 * [Ruby style guide](https://github.com/bbatsov/ruby-style-guide)


### PR DESCRIPTION
I think it's a good idea to start adding references for security guidelines in our playbook - I like this one that's related strictly to Rails (we could add more types afterwards).