### PR TITLE
Remove Hackday from playbook

### DIFF
--- a/docs/1.1-sharing.md
+++ b/docs/1.1-sharing.md
@@ -44,10 +44,6 @@ The most important thing to remember is that you'll leave the best impression - 
 
 On request, MLabs will cover the cost of a conference ticket. If you're going to speak at a conference related with what we do at the organization, we cover the cost of travel and accommodation, anywhere in reach of a budget flight.
 
-## Monthly Hackday
-
-Once a month we run a hackday. This event is based on the [Open Source Friday](https://opensourcefriday.com/businesses) initiative. It's a special day in which we contribute to open source projects, prototype stuff, test new technologies, write blog posts or create new products. During the month we [collect ideas](https://trello.com/b/6Qg8rle1/guia-dos-mochileiros) and on the last Friday of the month we choose some of them to work on.
-
 ## Open Source Software
 
 Open source is part of our philosophy. Since our inception, we've been an open source focused company, improving code shared by others, putting effort in writing code and generally supporting the open source movement. We build our products using open source tools almost exclusively.


### PR DESCRIPTION
We're thinking in other ways to invest our free time in a productive way. We want to use this time for stuff that help us learn new things, test new technologies, write blogposts/talks and help open source software.

The current hackday's format did no work as we expected:
* For most of the projects one day is not enough to deliver something meaninful
* One day per month is not productive
* Most of the time we did not organize the projects

We still see value in using the free time for investing in those stuff, but we would like to think in new formats that help us deliver real value.

Please comment in this PR so we can think in ways to overcome the problems.